### PR TITLE
Fix missing autoprefixer for Netlify build

### DIFF
--- a/admin-portal/package.json
+++ b/admin-portal/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@eslint/js": "^9.30.1",
     "@tailwindcss/postcss": "^4.1.11",
+    "autoprefixer": "^10.4.19",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.3.1",


### PR DESCRIPTION
## Summary
- add `autoprefixer` to dev dependencies for the admin portal

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fb595374883229a3ffee78170a629