### PR TITLE
Fix PageForm content_blocks parsing

### DIFF
--- a/admin-portal/src/components/PageForm.jsx
+++ b/admin-portal/src/components/PageForm.jsx
@@ -13,10 +13,18 @@ function PageForm({ item, onSave, onCancel }) {
   });
 
   useEffect(() => {
-        if (item) {
+    if (item) {
+      let blocks = item.content_blocks || [];
+      if (typeof blocks === 'string') {
+        try {
+          blocks = JSON.parse(blocks);
+        } catch (err) {
+          blocks = [];
+        }
+      }
       setFormData({
         ...item,
-        content_blocks: item.content_blocks || [], // Ensure content_blocks is an array
+        content_blocks: blocks, // Ensure content_blocks is an array
       });
     }
   }, [item]);


### PR DESCRIPTION
## Summary
- handle stringified content_blocks when initializing PageForm

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687fc17513608322970f51a4cf68500f